### PR TITLE
Pass pool:false to request to disable agent pooling.

### DIFF
--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -103,7 +103,8 @@ RecurlyData.base_options = function ()
 		{
 			'Accept': 'application/xml',
 			'Authorization': AUTH_BASIC
-		}
+		},
+		pool: false
 	};
 };
 


### PR DESCRIPTION
This prevents a massive queue pileup when requests are going slow
